### PR TITLE
add webc to github-linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.webc linguist-language=html


### PR DESCRIPTION
This adds syntax highlighting when viewing .webc files on Github.com