### PR TITLE
Update YT link to skip countdown

### DIFF
--- a/src/_components/page-nav.webc
+++ b/src/_components/page-nav.webc
@@ -44,7 +44,7 @@
 <nav>
   <ol>
     <li><a href="/">Home</a></li>
-		<li><a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M" data-icon="▶️">Watch on YouTube</a></li>
+		<li><a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M&t=1204s" data-icon="▶️">Watch on YouTube</a></li>
     <!-- <li><a href="/#when">What/When</a></li> -->
     <!-- <li><a href="/#register" data-icon="🎉">Register</a></li> -->
     <li><a href="/#sponsors">Sponsors</a></li>

--- a/src/_includes/layout.webc
+++ b/src/_includes/layout.webc
@@ -45,14 +45,14 @@ const showTitle = true;
 	</head>
 	<body>
 		<page-nav></page-nav>
-<!--- <announcement-banner @url="https://www.youtube.com/watch?v=iLxJ6PtuF9M">Review the stream on YouTube!</announcement-banner> --->
+<!--- <announcement-banner @url="https://www.youtube.com/watch?v=iLxJ6PtuF9M&t=1204s">Review the stream on YouTube!</announcement-banner> --->
 		<header webc:if="showTitle">
 			<!--- <sub-title webc:if="page.url == '/'">Join us for the</sub-title> --->
 			<giant-title :@condensed-title="condensedTitle" :@title-scale="titleScale"></giant-title>
 		</header>
 		<main id="content">
 <!---
-			<h2><a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M">Watch on YouTube</a></h2>
+			<h2><a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M&t=1204s">Watch on YouTube</a></h2>
 			<div class="rhythm">
 				<lite-youtube videoid="iLxJ6PtuF9M" playlabel="Play: 11ty Conference"></lite-youtube>
 			</div>

--- a/src/index.webc
+++ b/src/index.webc
@@ -19,8 +19,8 @@ const layout = "layout.webc";
 
 <p>View the <a href="#schedule">full schedule below</a>!</p>
 
-<h2 id="watch"><a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M">Watch on YouTube</a></h2>
-<p><em data-icon="🗓️">May 10 Update</em>: Video of the <a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M">full stream is available on YouTube</a>. Individual talk videos will be available in the coming weeks!</p>
+<h2 id="watch"><a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M&t=1204s">Watch on YouTube</a></h2>
+<p><em data-icon="🗓️">May 10 Update</em>: Video of the <a href="https://www.youtube.com/watch?v=iLxJ6PtuF9M&t=1204s">full stream is available on YouTube</a>. Individual talk videos will be available in the coming weeks!</p>
 
 <div id="subscription"></div>
 <div id="code-of-conduct"></div>


### PR DESCRIPTION
Using `&t=1204s` at the end of the YouTube link skips the countdown: 

https://www.youtube.com/watch?v=iLxJ6PtuF9M&t=1204s

Example from Mastodon: 

https://mastodon.social/@rdela/112423380498677595